### PR TITLE
Corrigido importação educacenso para tratar corretamente os ids inep.

### DIFF
--- a/ieducar/intranet/include/EducacensoParser.inc.php
+++ b/ieducar/intranet/include/EducacensoParser.inc.php
@@ -86,20 +86,20 @@ class EducacensoParser {
         		return $this->check_matricula($data);
         }
     }
-    
+
     protected function check_turma($d) {
         $logs = "";
-        $id_turma_inep = intval($d['codigo_inep_turma']);
+        $id_turma_inep = $d['codigo_inep_turma'];
         $tipo_atendimento = intval($d['tipo_atendimento']);
-        
+
         // Por enquanto, não tratamos turmas que não sejam padrão.
         if ($tipo_atendimento != 0) {
             $logs = "Turma $id_turma_inep não será importada (tipo: $tipo_atendimento)";
             return $logs;
-        } 
-        
+        }
+
         $id_turma = clsPmIeducarTurma::id_turma_inep($id_turma_inep);
-        
+
         if ($id_turma) {
             $logs .= "Turma $id_turma_inep encontrada. Não será atualizada.\n";
         } else {
@@ -405,52 +405,52 @@ class EducacensoParser {
         $escola_id = $escola->cadastra();
         $escola->cod_escola = $escola_id;
         $escola->vincula_educacenso($d['codigo_inep'], 'Importador');
-        
+
         $municipio = new clsMunicipio();
         $municipio = $municipio->by_id_IBGE($d['_municipio']);
-        
+
         foreach (array(1 => 'telefone', 2 => 'telefone_publico', 3 => 'telefone_outro', 4 => 'fax') as $t => $f) {
             if ((bool)$d['_ddd'] && (bool)$d[$f]) {
                 $telefone = new clsPessoaTelefone(
-                        $id_pessoa, 
-                        $t, 
-                        str_replace( "-", "", $d[$f]), 
-                        $d['_ddd'] 
+                        $id_pessoa,
+                        $t,
+                        str_replace( "-", "", $d[$f]),
+                        $d['_ddd']
                 );
                 $telefone->cadastra();
             }
         }
-        
-        $endereco = new clsEnderecoExterno( 
-                $id_pessoa, 
-                "1", 
-                'QDA', 
-                $d['endereco'], 
-                preg_replace( '/[^0-9]/', '', $d['endereco_numero']),  
+
+        $endereco = new clsEnderecoExterno(
+                $id_pessoa,
+                "1",
+                'QDA',
+                $d['endereco'],
+                preg_replace( '/[^0-9]/', '', $d['endereco_numero']),
                 null, // Letra é um campo text de length 1.
-                $d['complemento'], 
-                strlen($d['bairro']) > 40 ? substr($d['bairro'], 0, 40) : $d['bairro'], 
-                idFederal2int($d['cep']), 
-                $municipio->nome, 
-                $municipio->sigla_uf, 
-                false 
+                $d['complemento'],
+                strlen($d['bairro']) > 40 ? substr($d['bairro'], 0, 40) : $d['bairro'],
+                idFederal2int($d['cep']),
+                $municipio->nome,
+                $municipio->sigla_uf,
+                false
         );
         $endereco->cadastra();
-        
+
         //TODO: Cadastro de cursos.
         //$curso_escola = new clsPmieducarEscolaCurso( $cadastrou, $campo, null, $this->pessoa_logada, null, null, 1 );
         //$cadastrou_ = $curso_escola->cadastra();
-       
-    } 
+
+    }
 
     protected function date_db($date) {
         return implode('-', array_reverse(explode('/', $date)));
     }
-    
+
     protected function add_professor($d) {
-        $id_professor_inep = intval($d['codigo_inep_profissional']);
-        $id_escola = clsPmieducarEscola::id_escola_inep(intval($d['codigo_inep_escola']));
-        
+        $id_professor_inep = $d['codigo_inep_profissional'];
+        $id_escola = clsPmieducarEscola::id_escola_inep($d['codigo_inep_escola']);
+
         $municipio_nascimento = new clsMunicipio();
         $municipio_residencia = new clsMunicipio();
         try {
@@ -637,20 +637,20 @@ class EducacensoParser {
     }
 
     protected function add_turma($d) {
-        $id_turma_inep = intval($d['codigo_inep_turma']);
-        $id_escola_inep = intval($d['codigo_inep_escola']);
-        $id_etapa_ensino = intval($d['_etapa_ensino']);
-        
+        $id_turma_inep = $d['codigo_inep_turma'];
+        $id_escola_inep = $d['codigo_inep_escola'];
+        $id_etapa_ensino = $d['_etapa_ensino'];
+
         $id_escola = clsPmieducarEscola::id_escola_inep($id_escola_inep);
 
         $id_tipo_turma = $this->tipo_turma($d);
-        
+
         $id_curso = $this->curso($id_etapa_ensino, $id_escola);
-        $id_serie = $this->serie($id_etapa_ensino, $id_curso, $id_escola); 
-        
+        $id_serie = $this->serie($id_etapa_ensino, $id_curso, $id_escola);
+
         $hora_inicio = sprintf("%02d:%02d:00", intval($d['horario_inicial_hora']), intval($d['horario_inicial_minuto']));
         $hora_fim = sprintf("%02d:%02d:00", intval($d['horario_final_hora']), intval($d['horario_final_minuto']));
-        
+
         $turma = new clsPmieducarTurma();
         $turma->ref_cod_instituicao = $this->instituicao_id;
         $turma->ref_cod_instituicao_regente = $this->instituicao_id;

--- a/ieducar/intranet/include/pessoa/clsEnderecoExterno.inc.php
+++ b/ieducar/intranet/include/pessoa/clsEnderecoExterno.inc.php
@@ -88,13 +88,13 @@ class clsEnderecoExterno
       $this->idtlog = $idtlog;
     }
 
-    $this->logradouro  = $logradouro;
+    $this->logradouro  = pg_escape_string($logradouro);
     $this->numero      = $numero;
     $this->letra       = $letra;
-    $this->complemento = $complemento;
-    $this->bairro      = $bairro;
+    $this->complemento = pg_escape_string($complemento);
+    $this->bairro      = pg_escape_string($bairro);
     $this->cep         = $cep;
-    $this->cidade      = $cidade;
+    $this->cidade      = pg_escape_string($cidade);
 
     $objSiglaUf = new clsUf($sigla_uf);
     if ($objPessoa->detalhe()) {

--- a/ieducar/intranet/include/pmieducar/clsPmieducarAluno.inc.php
+++ b/ieducar/intranet/include/pmieducar/clsPmieducarAluno.inc.php
@@ -1132,12 +1132,12 @@ class clsPmieducarAluno
           $db = new clsBanco();
           $db->Consulta(sprintf("INSERT INTO modules.educacenso_cod_aluno " .
                   "(cod_aluno, cod_aluno_inep, fonte, created_at) VALUES " .
-                  "(%d, %d, '%s', NOW());", $this->cod_aluno, $cod_inep, $fonte));
+                  "(%s, %s, '%s', NOW());", $this->cod_aluno, $cod_inep, $fonte));
           return true;
       }
       return false;
   }
-  
+
   /**
    * Define quais campos da tabela serão selecionados no método Lista().
    */

--- a/ieducar/intranet/include/pmieducar/clsPmieducarEscola.inc.php
+++ b/ieducar/intranet/include/pmieducar/clsPmieducarEscola.inc.php
@@ -680,11 +680,11 @@ class clsPmieducarEscola
   public function vincula_educacenso ($cod_inep, $fonte = '') {
       if (!clsPmieducarEscola::id_escola_inep($cod_inep)) {
           $db = new clsBanco();
-          $db->Consulta(sprintf("INSERT INTO modules.educacenso_cod_escola " . 
+          $db->Consulta(sprintf("INSERT INTO modules.educacenso_cod_escola " .
                   "(cod_escola, cod_escola_inep, fonte, created_at) VALUES " .
-                  "(%d, %d, '%s', NOW());", $this->cod_escola, $cod_inep, $fonte));
+                  "(%s, %s, '%s', NOW());", $this->cod_escola, $cod_inep, $fonte));
           return true;
-      } 
+      }
       return false;
   }
 

--- a/ieducar/intranet/include/pmieducar/clsPmieducarServidor.inc.php
+++ b/ieducar/intranet/include/pmieducar/clsPmieducarServidor.inc.php
@@ -1203,12 +1203,12 @@ class clsPmieducarServidor
           $db = new clsBanco();
           $db->Consulta(sprintf("INSERT INTO modules.educacenso_cod_docente " .
                   "(cod_servidor, cod_docente_inep, fonte, created_at) VALUES " .
-                  "(%d, %d, '%s', NOW());", $this->cod_servidor, $cod_inep, $fonte));
+                  "(%s, %s, '%s', NOW());", $this->cod_servidor, $cod_inep, $fonte));
           return true;
       }
       return false;
   }
-  
+
   /**
    * Define quais campos da tabela serão selecionados no método Lista().
    */

--- a/ieducar/intranet/include/pmieducar/clsPmieducarTurma.inc.php
+++ b/ieducar/intranet/include/pmieducar/clsPmieducarTurma.inc.php
@@ -2044,12 +2044,12 @@ and  e.cod_escola = t.ref_ref_cod_escola
 	        $db = new clsBanco();
 	        $db->Consulta(sprintf("INSERT INTO modules.educacenso_cod_turma " .
                   "(cod_turma, cod_turma_inep, fonte, created_at) VALUES " .
-                  "(%d, %d, '%s', NOW());", $this->cod_turma, $cod_inep, $fonte));
+                  "(%s, %s, '%s', NOW());", $this->cod_turma, $cod_inep, $fonte));
 	        return true;
 	    }
 	    return false;
 	}
-	
+
 	/**
 	 * Define quais campos da tabela serao selecionados na invocacao do metodo lista
 	 *


### PR DESCRIPTION
* Em alguns casos os ids fornecidos pelo INEP são maiores que o maximo
para um valor inteiro.

  Por este motivo não pode-se usar funções como intval, ou o argumento
  %d junto a função sprintf.

  Pois ids como 124669026568 seriam transformados em 2147483647.

* A não correção deste erro, faria com que os registros cujo id inep é
  maior que 2147483647 sejam gravados com o mesmo id (2147483647).

* Isto tambem causaria a duplicação de dados, uma vez que os scripts de
  importação não encontrariam um registro já importando com o id inep
  (uma vez que o id estaria gravado como 2147483647, não batendo com o
  id inep procurado.